### PR TITLE
Fix useMavenNKLocal() so it works with latest Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 
     // Test Dependencies
     // Friends don't let friends use other unit testing frameworks...
-    testImplementation('org.spockframework:spock-core:0.7-groovy-2.0') {
+    testImplementation('org.spockframework:spock-core:2.3-groovy-3.0') {
         exclude module: "groovy-all"
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-3.3-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-3.3-bin.zip

--- a/src/main/groovy/org/netkernel/gradle/plugin/NetKernelPlugin.groovy
+++ b/src/main/groovy/org/netkernel/gradle/plugin/NetKernelPlugin.groovy
@@ -7,7 +7,6 @@ import org.gradle.api.tasks.Delete
 import org.gradle.api.publish.*
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository;
 import org.gradle.api.tasks.bundling.Jar
-import org.gradle.internal.impldep.org.apache.maven.project.ProjectUtils;
 import org.netkernel.gradle.plugin.model.*
 import org.netkernel.gradle.plugin.tasks.*
 import org.gradle.util.GradleVersion

--- a/src/main/groovy/org/netkernel/gradle/plugin/model/NetKernelExtension.groovy
+++ b/src/main/groovy/org/netkernel/gradle/plugin/model/NetKernelExtension.groovy
@@ -110,7 +110,7 @@ class NetKernelExtension {
     }
 
     void useMavenNKLocal() {
-        useMaven propertyHelper.findProjectProperty(project, PropertyHelper.MAVEN_LOCAL_URL)
+        useMaven(propertyHelper.findProjectProperty(project, PropertyHelper.MAVEN_LOCAL_URL), true)
     }
 
     void useMavenNK() {
@@ -118,9 +118,15 @@ class NetKernelExtension {
         useMaven propertyHelper.findProjectProperty(project, PropertyHelper.MAVEN_NETKERNEL_URL)
     }
 
-    void useMaven(String repoURL) {
+    void useMaven(String repoURL, boolean mAllowInsecureProtocol = false) {
         println("Adding repo: ${repoURL}")
-        project.repositories.maven { url repoURL }
+        project.repositories.maven {
+            url repoURL
+            if (mAllowInsecureProtocol) {
+                println("Setting allowInsecureProtocol for repo")
+                allowInsecureProtocol = true
+            }
+        }
     }
 
     void useMavenCentral() {


### PR DESCRIPTION
Latest Gradle require opt-in for non-secure protocols for maven repos (e.g. to allow HTTP instead of HTTPS). This change sets that opt-in on for local maven repo (i.e. when useMavenNKLocal() is used).